### PR TITLE
Add scripts for installing Lerna and buliding SPAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # heroku-buildpack-single-page-apps
-Builds and deploys SPAs using Lerna
+
+Builds SPAs using Lerna

--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+cd $1/client
+echo "-----> Installing Lerna"
+npm install -D lerna
+
+echo "-----> Bootstrapping Lerna"
+npx lerna bootstrap
+
+echo "-----> Building SPAs"
+npx lerna ci:deploy

--- a/bin/detect
+++ b/bin/detect
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [[ -f $1/client/lerna.json ]]; then
+  echo "-----> Build SPA"
+  exit 0
+else
+  exit 1
+fi

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+cat <<EOF
+---
+EOF


### PR DESCRIPTION
## Context
When building `zadev`, we need a way to build the SPAs and move the contents to the `public` directory to be served by Rails. This buildpack executes a Lerna command that does this.